### PR TITLE
BugFix at werkzeug version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 flask==2.2.2
 flask_socketio==5.3.2
 pyshark==0.5.3
+Werkzeug==2.2.2


### PR DESCRIPTION
python3 GsmEvil.py
Traceback (most recent call last):
  File "/usr/src/gsmevil2/GsmEvil.py", line 20, in <module>
    from flask import Flask, render_template, request
  File "/usr/local/lib/python3.10/dist-packages/flask/__init__.py", line 5, in <module>
    from .app import Flask as Flask
  File "/usr/local/lib/python3.10/dist-packages/flask/app.py", line 30, in <module>
    from werkzeug.urls import url_quote
ImportError: cannot import name 'url_quote' from 'werkzeug.urls' (/usr/local/lib/python3.10/dist-packages/werkzeug/urls.py)