### PR TITLE
Updated requirements.txt - added explicit version of Werkzeug (2.x)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 flask==2.2.2
 flask_socketio==5.3.2
 pyshark==0.5.3
+Werkzeug==2.2.2


### PR DESCRIPTION
After installing requrements, and after running script I spotted, the next rutime error:

```
ImportError: cannot import name 'url_quote' from 'werkzeug.urls'
```

After searching this issue I found solution, described here: https://stackoverflow.com/a/77214086/

> It is because Werkzeug 3.0.0 was released and Flask doesn't specify the dependency correctly

----

As described in StackOverflow answer:

> Solution: Just set a fix version for Werkzeug such as Werkzeug==2.2.2 in your requirements.txt and it should work.

I confirm that everything works.